### PR TITLE
Add error handling for permissions and user operations

### DIFF
--- a/metabase/permissions_group.go
+++ b/metabase/permissions_group.go
@@ -36,6 +36,10 @@ func CreatePermissionsGroup(ctx context.Context, client *Client, permissionsGrou
 			return PermissionsGroup{}, err
 		}
 
+		if resp.StatusCode() != 200 {
+			return PermissionsGroup{}, fmt.Errorf("error creating permissions group")
+		}
+
 		return permissionsGroupResponse, nil
 	case "v0.51":
 		createdPermissionsGroup, err := client.V0_51.Client.PostPermissionsGroup(ctx, metabase_v0_51.PostPermissionsGroupJSONRequestBody{
@@ -54,6 +58,10 @@ func CreatePermissionsGroup(ctx context.Context, client *Client, permissionsGrou
 		err = json.Unmarshal(resp.Body, &permissionsGroupResponse)
 		if err != nil {
 			return PermissionsGroup{}, err
+		}
+
+		if resp.StatusCode() != 200 {
+			return PermissionsGroup{}, fmt.Errorf("error creating permissions group")
 		}
 
 		return permissionsGroupResponse, nil
@@ -82,6 +90,10 @@ func GetPermissionsGroup(ctx context.Context, client *Client, permissionsGroupID
 			return PermissionsGroup{}, err
 		}
 
+		if resp.StatusCode() != 200 {
+			return PermissionsGroup{}, fmt.Errorf("error getting permissions group")
+		}
+
 		return permissionsGroupResponse, nil
 	case "v0.51":
 		permissionsGroup, err := client.V0_51.Client.GetPermissionsGroupId(ctx, permissionsGroupID)
@@ -98,6 +110,10 @@ func GetPermissionsGroup(ctx context.Context, client *Client, permissionsGroupID
 		err = json.Unmarshal(resp.Body, &permissionsGroupResponse)
 		if err != nil {
 			return PermissionsGroup{}, err
+		}
+
+		if resp.StatusCode() != 200 {
+			return PermissionsGroup{}, fmt.Errorf("error getting permissions group")
 		}
 
 		return permissionsGroupResponse, nil
@@ -128,6 +144,10 @@ func UpdatePermissionsGroup(ctx context.Context, client *Client, permissionsGrou
 			return PermissionsGroup{}, err
 		}
 
+		if resp.StatusCode() != 200 {
+			return PermissionsGroup{}, fmt.Errorf("error updating permissions group")
+		}
+
 		return permissionsGroupResponse, nil
 	case "v0.51":
 		updatedPermissionsGroup, err := client.V0_51.Client.PutPermissionsGroupGroupId(ctx, permissionsGroup.ID, metabase_v0_51.PutPermissionsGroupGroupIdJSONRequestBody{
@@ -146,6 +166,10 @@ func UpdatePermissionsGroup(ctx context.Context, client *Client, permissionsGrou
 		err = json.Unmarshal(resp.Body, &permissionsGroupResponse)
 		if err != nil {
 			return PermissionsGroup{}, err
+		}
+
+		if resp.StatusCode() != 200 {
+			return PermissionsGroup{}, fmt.Errorf("error updating permissions group")
 		}
 
 		return permissionsGroupResponse, nil

--- a/metabase/permissions_membership.go
+++ b/metabase/permissions_membership.go
@@ -52,6 +52,10 @@ func CreatePermissionsMembership(ctx context.Context, client *Client, permission
 			return PermissionsMembership{}, err
 		}
 
+		if createdPermissionsMembership.StatusCode != 200 {
+			return PermissionsMembership{}, fmt.Errorf("error creating permissions membership")
+		}
+
 		for _, membership := range permissionsGroupMemebershipResponse {
 			if membership.UserID == permissionsMembership.UserID {
 
@@ -80,6 +84,10 @@ func CreatePermissionsMembership(ctx context.Context, client *Client, permission
 		err = json.NewDecoder(createdPermissionsMembership.Body).Decode(&permissionsGroupMemebershipResponse)
 		if err != nil {
 			return PermissionsMembership{}, err
+		}
+
+		if createdPermissionsMembership.StatusCode != 200 {
+			return PermissionsMembership{}, fmt.Errorf("error creating permissions membership")
 		}
 
 		for _, membership := range permissionsGroupMemebershipResponse {
@@ -126,6 +134,10 @@ func UpdatePermissionsMembership(ctx context.Context, client *Client, permission
 			return PermissionsMembership{}, err
 		}
 
+		if resp.StatusCode() != 200 {
+			return PermissionsMembership{}, fmt.Errorf("error updating permissions membership")
+		}
+
 		return permissionsMembershipResponse, nil
 	case "v0.51":
 		updatedPermissionsMembership, err := client.V0_51.Client.PutPermissionsMembershipId(ctx, permissionsMembership.ID, metabase_v0_51.PutPermissionsMembershipIdJSONRequestBody{
@@ -148,6 +160,10 @@ func UpdatePermissionsMembership(ctx context.Context, client *Client, permission
 		err = json.Unmarshal(resp.Body, &permissionsMembershipResponse)
 		if err != nil {
 			return PermissionsMembership{}, err
+		}
+
+		if resp.StatusCode() != 200 {
+			return PermissionsMembership{}, fmt.Errorf("error updating permissions membership")
 		}
 
 		return permissionsMembershipResponse, nil
@@ -194,6 +210,10 @@ func GetPermissionsMembership(ctx context.Context, client *Client, membershipID,
 			return PermissionsMembership{}, err
 		}
 
+		if permissionsMembership.StatusCode != 200 {
+			return PermissionsMembership{}, fmt.Errorf("error getting permissions membership")
+		}
+
 		for _, membership := range permissionsMemebershipResponse[strconv.Itoa(userID)] {
 			if membership.MembershipID == membershipID {
 				return PermissionsMembership{
@@ -217,6 +237,10 @@ func GetPermissionsMembership(ctx context.Context, client *Client, membershipID,
 		err = json.NewDecoder(permissionsMembership.Body).Decode(&permissionsMemebershipResponse)
 		if err != nil {
 			return PermissionsMembership{}, err
+		}
+
+		if permissionsMembership.StatusCode != 200 {
+			return PermissionsMembership{}, fmt.Errorf("error getting permissions membership")
 		}
 
 		for _, membership := range permissionsMemebershipResponse[strconv.Itoa(userID)] {

--- a/metabase/user.go
+++ b/metabase/user.go
@@ -39,6 +39,11 @@ func CreateUser(ctx context.Context, client *Client, user User) (User, error) {
 		if err != nil {
 			return User{}, err
 		}
+
+		if resp.StatusCode() != 200 {
+			return User{}, fmt.Errorf("error creating user")
+		}
+
 		return userResponse, nil
 	case "v0.51":
 		createdUser, err := client.V0_51.Client.PostUser(ctx, metabase_v0_51.PostUserJSONRequestBody{
@@ -61,7 +66,9 @@ func CreateUser(ctx context.Context, client *Client, user User) (User, error) {
 			return User{}, err
 		}
 
-		fmt.Println(userResponse)
+		if resp.StatusCode() != 200 {
+			return User{}, fmt.Errorf("error creating user")
+		}
 
 		return userResponse, nil
 	default:
@@ -89,6 +96,10 @@ func GetUser(ctx context.Context, client *Client, id int) (User, error) {
 			return User{}, err
 		}
 
+		if resp.StatusCode() != 200 {
+			return User{}, fmt.Errorf("error getting user")
+		}
+
 		return userResponse, nil
 	case "v0.51":
 		user, err := client.V0_51.Client.GetUserId(ctx, id)
@@ -105,6 +116,10 @@ func GetUser(ctx context.Context, client *Client, id int) (User, error) {
 		err = json.Unmarshal(resp.Body, &userResponse)
 		if err != nil {
 			return User{}, err
+		}
+
+		if resp.StatusCode() != 200 {
+			return User{}, fmt.Errorf("error getting user")
 		}
 
 		return userResponse, nil
@@ -137,6 +152,10 @@ func UpdateUser(ctx context.Context, client *Client, user User) (User, error) {
 			return User{}, err
 		}
 
+		if resp.StatusCode() != 200 {
+			return User{}, fmt.Errorf("error updating user")
+		}
+
 		return userResponse, nil
 	case "v0.51":
 		updatedUser, err := client.V0_51.Client.PutUserId(ctx, user.ID, metabase_v0_51.PutUserIdJSONRequestBody{
@@ -157,6 +176,10 @@ func UpdateUser(ctx context.Context, client *Client, user User) (User, error) {
 		err = json.Unmarshal(resp.Body, &userResponse)
 		if err != nil {
 			return User{}, err
+		}
+
+		if resp.StatusCode() != 200 {
+			return User{}, fmt.Errorf("error updating user")
 		}
 
 		return userResponse, nil


### PR DESCRIPTION
Implement error handling for creating, retrieving, and updating permissions groups, memberships, and users to improve robustness and provide clearer feedback on failures.