### PR TITLE
Fix(permissions_membership): terraform delete error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ website/vendor
 
 # Ignore the provider binary. Used for local testing.
 terraform-provider-metabase 
+
+tmp/

--- a/internal/provider/permissions_membership_resource.go
+++ b/internal/provider/permissions_membership_resource.go
@@ -157,8 +157,6 @@ func (r *PermissionsMembershipResource) Delete(ctx context.Context, req resource
 		resp.Diagnostics.AddError("failed to delete membership", err.Error())
 		return
 	}
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, nil)...)
 }
 
 func (r *PermissionsMembershipResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {


### PR DESCRIPTION
Error when delete user from a group.

```
│ Error: State Read Error
│
│ An unexpected error was encountered trying to write the state. This is always an error in the provider. Please report the following to the provider developer:
│
│ cannot set nil as entire state; to remove a resource from state, call State.RemoveResource, instead
```